### PR TITLE
15 bug nothing here text misaligned

### DIFF
--- a/app/src/main/java/com/nickspatties/timeclock/ui/components/NothingHereText.kt
+++ b/app/src/main/java/com/nickspatties/timeclock/ui/components/NothingHereText.kt
@@ -7,33 +7,28 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.nickspatties.timeclock.R
 
 @Composable
-fun NothingHereText() {
+fun NothingHereText(
+    text: String = stringResource(id = R.string.list_page_nothing_here)
+) {
     Column(
         modifier = Modifier
             .fillMaxHeight()
             .fillMaxWidth()
-            .padding(
-                horizontal = 8.dp
-            ),
+            .padding(horizontal = 8.dp),
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement = Arrangement.Center
     ) {
-        val size = 24.sp
-        val color = MaterialTheme.colors.onSurface.copy(alpha = 0.33f)
         Text(
-            text = stringResource(R.string.list_page_nothing_here),
-            fontSize = size,
-            color = color
-        )
-        Text(
-            text = stringResource(R.string.list_page_fill_this_list),
-            fontSize = size,
-            color = color
+            text = text,
+            fontSize = 24.sp,
+            color = MaterialTheme.colors.onSurface.copy(alpha = 0.33f),
+            textAlign = TextAlign.Center
         )
     }
 }

--- a/app/src/main/java/com/nickspatties/timeclock/ui/components/NothingHereText.kt
+++ b/app/src/main/java/com/nickspatties/timeclock/ui/components/NothingHereText.kt
@@ -26,7 +26,7 @@ fun NothingHereText(
     ) {
         Text(
             text = text,
-            fontSize = 24.sp,
+            style = MaterialTheme.typography.h6,
             color = MaterialTheme.colors.onSurface.copy(alpha = 0.33f),
             textAlign = TextAlign.Center
         )

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -9,8 +9,7 @@
     <string name="task_saved_toast">Task \"%s\" saved!</string>
     <string name="task_text_field_label">What are you gonna do now?</string>
     <string name="task_text_field_placeholder">Right now, I\'m gonna be…</string>
-    <string name="list_page_nothing_here">Looks like there\'s nothing here.</string>
-    <string name="list_page_fill_this_list">Record some events to fill this list!</string>
+    <string name="list_page_nothing_here">Looks like there\'s nothing here… Record some events to fill this list!</string>
     <string name="list_page_in_progress">In progress…</string>
     <string name="start_time">Start time</string>
     <string name="end_time">End time</string>


### PR DESCRIPTION
### Changes
* Changed `NothingHereText` component to center text with `TextAlign` property
* Allow parameter to be passed into component, but provide default one just in case

### Related issue
Fixes issue #15 

### Screenshots
<details>
<summary>Before: misaligned text</summary>

<img src="https://user-images.githubusercontent.com/3261001/179301151-1854abc6-a1d8-4ae7-960c-bbe588bec390.png" width="250px" />
</details>

<details>
<summary>After: centered relative to parent</summary>

<img src="https://user-images.githubusercontent.com/3261001/179310906-9a4d1fac-5919-453e-bf0e-593507f16838.png" width="250px" />
<img src="https://user-images.githubusercontent.com/3261001/179310910-b26cfa88-c047-4845-a02f-69e17691231e.png" width="250px" />
</details>

<details>
<summary>Bonus: "nothing here" text appears when individual analysis pane has no data</summary>

Related to feature addition in #11 
<img src="https://user-images.githubusercontent.com/3261001/179311281-0c98cdc4-38d4-4ab9-9d51-579e2f869d47.jpg" width="250px" />
<img src="https://user-images.githubusercontent.com/3261001/179311287-bdd08af2-2001-4430-8103-b173ae6fc61b.jpg" width="250px" />
</details>

### Testing
* Manual testing on both Android emulator and actual device of different screen sizes