### PR TITLE
Don't count past zero when counting down

### DIFF
--- a/app/src/main/java/com/nickspatties/timeclock/ui/viewmodel/ClockPageViewModel.kt
+++ b/app/src/main/java/com/nickspatties/timeclock/ui/viewmodel/ClockPageViewModel.kt
@@ -401,6 +401,7 @@ class ClockPageViewModel (
         currCountDownSeconds = calculateCurrCountDownSeconds(countDownEndTime)
         if(currCountDownSeconds <= 0) {
             stopClock(tappedStopButton = false)
+            currCountDownSeconds = 0
         }
         updateCountDownTextFieldValues(currCountDownSeconds)
     }

--- a/app/src/main/java/com/nickspatties/timeclock/ui/viewmodel/ClockPageViewModel.kt
+++ b/app/src/main/java/com/nickspatties/timeclock/ui/viewmodel/ClockPageViewModel.kt
@@ -398,11 +398,32 @@ class ClockPageViewModel (
     }
 
     private fun countDown() {
-        currCountDownSeconds = calculateCurrCountDownSeconds(countDownEndTime)
-        if(currCountDownSeconds <= 0) {
-            stopClock(tappedStopButton = false)
-            currCountDownSeconds = 0
-        }
-        updateCountDownTextFieldValues(currCountDownSeconds)
+        currCountDownSeconds = getCountDownSeconds(
+            countDownEndTime = countDownEndTime,
+            stopClockFunc = this::stopClock,
+            updateFields = this::updateCountDownTextFieldValues
+        )
     }
+}
+
+/**
+ * Gets the current count down seconds based on an end time. If the end time has
+ * already passed, then call the stopClock function. Updates the text with the
+ * updateFields function.
+ *
+ * This really allows me to quickly test the fix for this bug:
+ * https://github.com/NicksPatties/timeclock/issues/12
+ */
+fun getCountDownSeconds(
+    countDownEndTime: Long = 0L,
+    stopClockFunc: (Boolean) -> Unit = {},
+    updateFields: (Int) -> Unit = {}
+): Int {
+    var currSeconds = calculateCurrCountDownSeconds(countDownEndTime)
+    if(currSeconds <= 0) {
+        stopClockFunc(false)
+        currSeconds = 0
+    }
+    updateFields(currSeconds)
+    return currSeconds
 }

--- a/app/src/test/java/com/nickspatties/timeclock/ui/viewmodel/ClockPageViewModelTest.kt
+++ b/app/src/test/java/com/nickspatties/timeclock/ui/viewmodel/ClockPageViewModelTest.kt
@@ -1,0 +1,15 @@
+package com.nickspatties.timeclock.ui.viewmodel
+
+import com.google.common.truth.Truth.assertThat
+import com.nickspatties.timeclock.util.MILLIS_PER_SECOND
+import org.junit.Test
+
+class ClockPageViewModelTest {
+
+    @Test
+    fun getCountDownSeconds_doesNotReturnNegativeNumber() {
+        val pastEndTime = System.currentTimeMillis() - MILLIS_PER_SECOND
+        val actualSeconds = getCountDownSeconds(pastEndTime)
+        assertThat(actualSeconds).isEqualTo(0)
+    }
+}


### PR DESCRIPTION
### Changes
* Set `currCountDownSeconds` to 0 when I count, and I'm currently past the event's scheduled end time
* Add a unit test to verify functionality

This fixes part of the bug with the related issue. Since the complete fix requires a new feature to guide the user to change their app's battery settings, the rest of the fix will occur when that feature is fleshed out and completed. For now, this removes the UI jank caused by `currCountDownSeconds` being a negative number.

### Related issue
#12 

### Testing
* Unit testing