### PR TITLE
19 feature notify users to change battery permission settings

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -4,6 +4,11 @@
 
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.SCHEDULE_EXACT_ALARM" />
+    <!--
+        Remove this permission below if the Settings.ACTION_REQUEST_IGNORE_BATTERY_OPTIMIZATIONS
+        activity is no longer being started in ClockPageViewModel::goToBatterySettings
+    -->
+    <uses-permission android:name="android.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS" />
 
     <application
         android:allowBackup="true"
@@ -15,7 +20,6 @@
         <activity
             android:name=".MainActivity"
             android:exported="true"
-            android:label="@string/app_name"
             android:theme="@style/Theme.TimeClock.NoActionBar"
             android:screenOrientation="portrait"
             android:launchMode="singleTask">

--- a/app/src/main/java/com/nickspatties/timeclock/MainActivity.kt
+++ b/app/src/main/java/com/nickspatties/timeclock/MainActivity.kt
@@ -139,27 +139,6 @@ fun NavigationComponent(
     startDestination: String
 ) {
     val clockPageViewModel = viewModel.clockPage
-    val clockEnabled = clockPageViewModel.clockButtonEnabled
-    val isRunning = clockPageViewModel.isClockRunning
-    val dropdownExpanded = clockPageViewModel.dropdownExpanded
-    // observe changes on autofillTaskNames to allow filteredTaskNames to function properly
-    clockPageViewModel.autofillTaskNames.observeAsState()
-    val filteredTaskNames = clockPageViewModel.filteredEventNames
-    val taskTextFieldValue = clockPageViewModel.taskTextFieldValue
-    val currSeconds = clockPageViewModel.currSeconds
-    val onTaskNameChange = clockPageViewModel::onTaskNameChange
-    val onTaskNameDonePressed = clockPageViewModel::onTaskNameDonePressed
-    val onDismissDropdown = clockPageViewModel::onDismissDropdown
-    val onDropdownMenuItemClick = clockPageViewModel::onDropdownMenuItemClick
-    val startClock = clockPageViewModel::startClock
-    val stopClock = clockPageViewModel::stopClock
-    val onTimerAnimationFinished = clockPageViewModel::resetCurrSeconds
-    val countdownEnabled = clockPageViewModel.countDownTimerEnabled
-    val onCountdownIconClicked = clockPageViewModel::switchCountDownTimer
-    val hoursTextFieldValue = clockPageViewModel.hoursTextFieldValue
-    val minutesTextFieldValue = clockPageViewModel.minutesTextFieldValue
-    val secondsTextFieldValue = clockPageViewModel.secondsTextFieldValue
-    val batteryWarningDialogVisible = clockPageViewModel.batteryWarningDialogVisible
 
     val listPageViewModel = viewModel.listPage
     val groupedEvents = listPageViewModel.groupedEventsByDate.observeAsState().value

--- a/app/src/main/java/com/nickspatties/timeclock/MainActivity.kt
+++ b/app/src/main/java/com/nickspatties/timeclock/MainActivity.kt
@@ -159,6 +159,7 @@ fun NavigationComponent(
     val hoursTextFieldValue = clockPageViewModel.hoursTextFieldValue
     val minutesTextFieldValue = clockPageViewModel.minutesTextFieldValue
     val secondsTextFieldValue = clockPageViewModel.secondsTextFieldValue
+    val batteryWarningDialogVisible = clockPageViewModel.batteryWarningDialogVisible
 
     val listPageViewModel = viewModel.listPage
     val groupedEvents = listPageViewModel.groupedEventsByDate.observeAsState().value
@@ -190,25 +191,7 @@ fun NavigationComponent(
     ) {
         composable(clockRoute) {
             ClockPage(
-                viewModel = clockPageViewModel,
-                clockEnabled = clockEnabled,
-                isRunning = isRunning,
-                dropdownExpanded = dropdownExpanded,
-                filteredTaskNames = filteredTaskNames,
-                taskTextFieldValue = taskTextFieldValue,
-                currSeconds = currSeconds,
-                onTaskNameChange = onTaskNameChange,
-                onTaskNameDonePressed = onTaskNameDonePressed,
-                onDismissDropdown = onDismissDropdown,
-                onDropdownMenuItemClick = onDropdownMenuItemClick,
-                startClock = startClock,
-                stopClock = stopClock,
-                timerAnimationFinishedListener = onTimerAnimationFinished,
-                onCountdownIconClicked = onCountdownIconClicked,
-                countdownEnabled = countdownEnabled,
-                hoursTextFieldValue = hoursTextFieldValue,
-                minutesTextFieldValue = minutesTextFieldValue,
-                secondsTextFieldValue = secondsTextFieldValue
+                viewModel = clockPageViewModel
             )
         }
         composable(listRoute) {

--- a/app/src/main/java/com/nickspatties/timeclock/data/UserPreferencesRepository.kt
+++ b/app/src/main/java/com/nickspatties/timeclock/data/UserPreferencesRepository.kt
@@ -18,14 +18,13 @@ data class UserPreferences(
     val countDownWarningEnabled: Boolean,
 )
 
-class UserPreferencesRepository(private val dataStore: DataStore<Preferences>) {
+object PreferenceKeys {
+    val COUNT_DOWN_END_TIME = longPreferencesKey("count_down_end_time")
+    val COUNT_DOWN_ENABLED = booleanPreferencesKey("count_down_enabled")
+    val COUNT_DOWN_WARNING_ENABLED = booleanPreferencesKey("count_down_warning_enabled")
+}
 
-    // list of keys that are used to maintain state in the app
-    private object PreferenceKeys {
-        val COUNT_DOWN_END_TIME = longPreferencesKey("count_down_end_time")
-        val COUNT_DOWN_ENABLED = booleanPreferencesKey("count_down_enabled")
-        val COUNT_DOWN_WARNING_ENABLED = booleanPreferencesKey("count_down_warning_enabled")
-    }
+class UserPreferencesRepository(private val dataStore: DataStore<Preferences>) {
 
     val userPreferencesFlow: Flow<UserPreferences> = dataStore.data
         .catch { exception ->
@@ -46,12 +45,6 @@ class UserPreferencesRepository(private val dataStore: DataStore<Preferences>) {
         return UserPreferences(countDownEnabled, countDownEndTime, countDownWarningEnabled)
     }
 
-    suspend fun updateCountDownEnabled(enabled: Boolean) {
-        dataStore.edit {
-            it[PreferenceKeys.COUNT_DOWN_ENABLED] = enabled
-        }
-    }
-
     suspend fun updateCountDownEndTime(endTime: Long) {
         dataStore.edit {
             it[PreferenceKeys.COUNT_DOWN_END_TIME] = endTime
@@ -61,6 +54,12 @@ class UserPreferencesRepository(private val dataStore: DataStore<Preferences>) {
     suspend fun updateCountDownWarningEnabled(enabled: Boolean) {
         dataStore.edit {
             it[PreferenceKeys.COUNT_DOWN_WARNING_ENABLED] = enabled
+        }
+    }
+
+    suspend fun <T> updatePreference(preference: Preferences.Key<T>, data: T) {
+        dataStore.edit {
+            it[preference] = data
         }
     }
 }

--- a/app/src/main/java/com/nickspatties/timeclock/data/UserPreferencesRepository.kt
+++ b/app/src/main/java/com/nickspatties/timeclock/data/UserPreferencesRepository.kt
@@ -14,14 +14,12 @@ import java.io.IOException
 
 data class UserPreferences(
     val countDownEnabled: Boolean,
-    val countDownEndTime: Long,
-    val countDownWarningEnabled: Boolean,
+    val countDownEndTime: Long
 )
 
 object PreferenceKeys {
     val COUNT_DOWN_END_TIME = longPreferencesKey("count_down_end_time")
     val COUNT_DOWN_ENABLED = booleanPreferencesKey("count_down_enabled")
-    val COUNT_DOWN_WARNING_ENABLED = booleanPreferencesKey("count_down_warning_enabled")
 }
 
 class UserPreferencesRepository(private val dataStore: DataStore<Preferences>) {
@@ -41,8 +39,7 @@ class UserPreferencesRepository(private val dataStore: DataStore<Preferences>) {
     private fun mapUserPreferences(preferences: Preferences): UserPreferences {
         val countDownEnabled = preferences[PreferenceKeys.COUNT_DOWN_ENABLED] ?: false
         val countDownEndTime = preferences[PreferenceKeys.COUNT_DOWN_END_TIME] ?: 0
-        val countDownWarningEnabled = preferences[PreferenceKeys.COUNT_DOWN_WARNING_ENABLED] ?: true
-        return UserPreferences(countDownEnabled, countDownEndTime, countDownWarningEnabled)
+        return UserPreferences(countDownEnabled, countDownEndTime)
     }
 
     suspend fun updateCountDownEndTime(endTime: Long) {
@@ -51,15 +48,9 @@ class UserPreferencesRepository(private val dataStore: DataStore<Preferences>) {
         }
     }
 
-    suspend fun updateCountDownWarningEnabled(enabled: Boolean) {
+    suspend fun updateCountDownEnabled(enabled: Boolean) {
         dataStore.edit {
-            it[PreferenceKeys.COUNT_DOWN_WARNING_ENABLED] = enabled
-        }
-    }
-
-    suspend fun <T> updatePreference(preference: Preferences.Key<T>, data: T) {
-        dataStore.edit {
-            it[preference] = data
+            it[PreferenceKeys.COUNT_DOWN_ENABLED] = enabled
         }
     }
 }

--- a/app/src/main/java/com/nickspatties/timeclock/data/UserPreferencesRepository.kt
+++ b/app/src/main/java/com/nickspatties/timeclock/data/UserPreferencesRepository.kt
@@ -14,7 +14,8 @@ import java.io.IOException
 
 data class UserPreferences(
     val countDownEnabled: Boolean,
-    val countDownEndTime: Long
+    val countDownEndTime: Long,
+    val countDownWarningEnabled: Boolean,
 )
 
 class UserPreferencesRepository(private val dataStore: DataStore<Preferences>) {
@@ -23,6 +24,7 @@ class UserPreferencesRepository(private val dataStore: DataStore<Preferences>) {
     private object PreferenceKeys {
         val COUNT_DOWN_END_TIME = longPreferencesKey("count_down_end_time")
         val COUNT_DOWN_ENABLED = booleanPreferencesKey("count_down_enabled")
+        val COUNT_DOWN_WARNING_ENABLED = booleanPreferencesKey("count_down_warning_enabled")
     }
 
     val userPreferencesFlow: Flow<UserPreferences> = dataStore.data
@@ -40,7 +42,8 @@ class UserPreferencesRepository(private val dataStore: DataStore<Preferences>) {
     private fun mapUserPreferences(preferences: Preferences): UserPreferences {
         val countDownEnabled = preferences[PreferenceKeys.COUNT_DOWN_ENABLED] ?: false
         val countDownEndTime = preferences[PreferenceKeys.COUNT_DOWN_END_TIME] ?: 0
-        return UserPreferences(countDownEnabled, countDownEndTime)
+        val countDownWarningEnabled = preferences[PreferenceKeys.COUNT_DOWN_WARNING_ENABLED] ?: true
+        return UserPreferences(countDownEnabled, countDownEndTime, countDownWarningEnabled)
     }
 
     suspend fun updateCountDownEnabled(enabled: Boolean) {
@@ -52,6 +55,12 @@ class UserPreferencesRepository(private val dataStore: DataStore<Preferences>) {
     suspend fun updateCountDownEndTime(endTime: Long) {
         dataStore.edit {
             it[PreferenceKeys.COUNT_DOWN_END_TIME] = endTime
+        }
+    }
+
+    suspend fun updateCountDownWarningEnabled(enabled: Boolean) {
+        dataStore.edit {
+            it[PreferenceKeys.COUNT_DOWN_WARNING_ENABLED] = enabled
         }
     }
 }

--- a/app/src/main/java/com/nickspatties/timeclock/ui/components/BatteryWarningDialog.kt
+++ b/app/src/main/java/com/nickspatties/timeclock/ui/components/BatteryWarningDialog.kt
@@ -1,0 +1,30 @@
+package com.nickspatties.timeclock.ui.components
+
+import androidx.compose.material.AlertDialog
+import androidx.compose.material.Text
+import androidx.compose.material.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import com.nickspatties.timeclock.R
+
+@Composable
+@Preview
+fun BatteryWarningDialog(
+    confirmFunction: () -> Unit = {},
+    dismissFunction: () -> Unit = {}
+) {
+    AlertDialog(
+        modifier = Modifier,
+        onDismissRequest = dismissFunction,
+        title = { Text(stringResource(id = R.string.battery_warning_dialog_title)) },
+        text = { Text(stringResource(id = R.string.battery_warning_dialog_body)) },
+        confirmButton = {
+            TextButton(onClick = confirmFunction) {
+                Text(text = stringResource(id = R.string.battery_warning_dialog_action).uppercase())
+            }
+        },
+        dismissButton = null
+    )
+}

--- a/app/src/main/java/com/nickspatties/timeclock/ui/pages/ClockPage.kt
+++ b/app/src/main/java/com/nickspatties/timeclock/ui/pages/ClockPage.kt
@@ -3,6 +3,7 @@ package com.nickspatties.timeclock.ui.pages
 import androidx.compose.foundation.layout.*
 import androidx.compose.material.*
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.livedata.observeAsState
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
@@ -22,28 +23,40 @@ import com.nickspatties.timeclock.ui.viewmodel.ClockPageViewModel
 @OptIn(ExperimentalComposeUiApi::class)
 @Composable
 fun ClockPage(
-    viewModel: ClockPageViewModel?,
-    clockEnabled: Boolean,
-    isRunning: Boolean,
-    countdownEnabled: Boolean = false,
-    dropdownExpanded: Boolean,
-    taskTextFieldValue: TextFieldValue,
-    filteredTaskNames: List<String> = listOf(),
-    currSeconds: Int,
-    onTaskNameChange: (TextFieldValue) -> Unit,
-    onTaskNameDonePressed: () -> Unit,
-    onDismissDropdown: () -> Unit,
-    onDropdownMenuItemClick: (String) -> Unit,
-    startClock: () -> Unit,
-    stopClock: (Boolean) -> Unit,
-    timerAnimationFinishedListener: () -> Unit = {},
-    onCountdownIconClicked: () -> Unit,
-    hoursTextFieldValue: TextFieldValue,
-    minutesTextFieldValue: TextFieldValue,
-    secondsTextFieldValue: TextFieldValue
+    viewModel: ClockPageViewModel
 ) {
+    // moving variables from the main activity to in here
+    val clockEnabled = viewModel.clockButtonEnabled
+    val isRunning = viewModel.isClockRunning
+    val dropdownExpanded = viewModel.dropdownExpanded
+    // observe changes on autofillTaskNames to allow filteredTaskNames to function properly
+    viewModel.autofillTaskNames.observeAsState()
+    val filteredTaskNames = viewModel.filteredEventNames
+    val taskTextFieldValue = viewModel.taskTextFieldValue
+    val currSeconds = viewModel.currSeconds
+    val onTaskNameChange = viewModel::onTaskNameChange
+    val onTaskNameDonePressed = viewModel::onTaskNameDonePressed
+    val onDismissDropdown = viewModel::onDismissDropdown
+    val onDropdownMenuItemClick = viewModel::onDropdownMenuItemClick
+    val startClock = viewModel::startClock
+    val stopClock = viewModel::stopClock
+    val onTimerAnimationFinished = viewModel::resetCurrSeconds
+    val countdownEnabled = viewModel.countDownTimerEnabled
+    val onCountdownIconClicked = viewModel::switchCountDownTimer
+    val hoursTextFieldValue = viewModel.hoursTextFieldValue
+    val minutesTextFieldValue = viewModel.minutesTextFieldValue
+    val secondsTextFieldValue = viewModel.secondsTextFieldValue
+    val batteryWarningDialogVisible = viewModel.batteryWarningDialogVisible
+
     val focusManager = LocalFocusManager.current
     val keyboardController = LocalSoftwareKeyboardController.current
+
+//    if (batteryWarningDialogVisible) {
+//        batteryWarningDialog(
+//            confirmFunction = { viewModel.goToBatterySettings() },
+//            dismissFunction = { viewModel.hideBatteryWarningModal() }
+//        )
+//    }
 
     Scaffold() {
         Column(
@@ -107,7 +120,7 @@ fun ClockPage(
             val spacing = 0.dp
             if (countdownEnabled) {
                 EditTimerTextField(
-                    viewModel = viewModel!!,
+                    viewModel = viewModel,
                     hoursTextFieldValue = hoursTextFieldValue,
                     minutesTextFieldValue = minutesTextFieldValue,
                     secondsTextFieldValue = secondsTextFieldValue,
@@ -122,7 +135,7 @@ fun ClockPage(
                     ),
                     isRunning = isRunning,
                     currSeconds = currSeconds,
-                    finishedListener = timerAnimationFinishedListener
+                    finishedListener = onTimerAnimationFinished
                 )
             }
 
@@ -138,16 +151,19 @@ fun ClockPage(
 
 @Composable
 @Preview
-fun someAlertDialog() {
+fun batteryWarningDialog(
+    confirmFunction: () -> Unit = {},
+    dismissFunction: () -> Unit = {}
+) {
     AlertDialog(
         modifier = Modifier,
-        onDismissRequest = { /*TODO*/ },
+        onDismissRequest = dismissFunction,
         title = { Text("Hey guess what?") },
         text = { Text("So there's some stuff that you gotta do with the battery settings and stuff? Yeah, that's pretty annoying.\n\nDo you mind changing those things? Thanks.")},
-        confirmButton = { TextButton(onClick = {}) {
+        confirmButton = { TextButton(onClick = confirmFunction) {
             Text(text = "Confirm".uppercase())
         }},
-        dismissButton = { TextButton(onClick = {}) {
+        dismissButton = { TextButton(onClick = dismissFunction) {
             Text("Deny".uppercase())
         }}
     )
@@ -156,23 +172,23 @@ fun someAlertDialog() {
 @Composable
 @Preview
 fun ClockPageMockUp() {
-    val defaultTextFieldValue = TextFieldValue("00")
-    ClockPage(
-        clockEnabled = false,
-        isRunning = false,
-        dropdownExpanded = false,
-        taskTextFieldValue = TextFieldValue(),
-        currSeconds = 0,
-        onTaskNameChange = { },
-        onTaskNameDonePressed = { },
-        onDismissDropdown = { },
-        onDropdownMenuItemClick = { },
-        startClock = { },
-        stopClock = { },
-        onCountdownIconClicked = {},
-        hoursTextFieldValue = defaultTextFieldValue,
-        minutesTextFieldValue = defaultTextFieldValue,
-        secondsTextFieldValue = defaultTextFieldValue,
-        viewModel = null
-    )
+//    val defaultTextFieldValue = TextFieldValue("00")
+//    ClockPage(
+//        clockEnabled = false,
+//        isRunning = false,
+//        dropdownExpanded = false,
+//        taskTextFieldValue = TextFieldValue(),
+//        currSeconds = 0,
+//        onTaskNameChange = { },
+//        onTaskNameDonePressed = { },
+//        onDismissDropdown = { },
+//        onDropdownMenuItemClick = { },
+//        startClock = { },
+//        stopClock = { },
+//        onCountdownIconClicked = {},
+//        hoursTextFieldValue = defaultTextFieldValue,
+//        minutesTextFieldValue = defaultTextFieldValue,
+//        secondsTextFieldValue = defaultTextFieldValue,
+//        viewModel = null
+//    )
 }

--- a/app/src/main/java/com/nickspatties/timeclock/ui/pages/ClockPage.kt
+++ b/app/src/main/java/com/nickspatties/timeclock/ui/pages/ClockPage.kt
@@ -1,10 +1,7 @@
 package com.nickspatties.timeclock.ui.pages
 
 import androidx.compose.foundation.layout.*
-import androidx.compose.material.DropdownMenu
-import androidx.compose.material.DropdownMenuItem
-import androidx.compose.material.Scaffold
-import androidx.compose.material.Text
+import androidx.compose.material.*
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.ExperimentalComposeUiApi
@@ -137,6 +134,23 @@ fun ClockPage(
             )
         }
     }
+}
+
+@Composable
+@Preview
+fun someAlertDialog() {
+    AlertDialog(
+        modifier = Modifier,
+        onDismissRequest = { /*TODO*/ },
+        title = { Text("Hey guess what?") },
+        text = { Text("So there's some stuff that you gotta do with the battery settings and stuff? Yeah, that's pretty annoying.\n\nDo you mind changing those things? Thanks.")},
+        confirmButton = { TextButton(onClick = {}) {
+            Text(text = "Confirm".uppercase())
+        }},
+        dismissButton = { TextButton(onClick = {}) {
+            Text("Deny".uppercase())
+        }}
+    )
 }
 
 @Composable

--- a/app/src/main/java/com/nickspatties/timeclock/ui/pages/ClockPage.kt
+++ b/app/src/main/java/com/nickspatties/timeclock/ui/pages/ClockPage.kt
@@ -13,10 +13,7 @@ import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.PopupProperties
-import com.nickspatties.timeclock.ui.components.EditTimerTextField
-import com.nickspatties.timeclock.ui.components.StartTimerButton
-import com.nickspatties.timeclock.ui.components.TaskTextField
-import com.nickspatties.timeclock.ui.components.TimerText
+import com.nickspatties.timeclock.ui.components.*
 import com.nickspatties.timeclock.ui.viewmodel.ClockPageViewModel
 
 @OptIn(ExperimentalComposeUiApi::class)
@@ -31,7 +28,7 @@ fun ClockPage(
     viewModel.autofillTaskNames.observeAsState()
 
     if (viewModel.batteryWarningDialogVisible) {
-        batteryWarningDialog(
+        BatteryWarningDialog(
             confirmFunction = { viewModel.goToBatterySettings() },
             dismissFunction = { viewModel.hideBatteryWarningModal() }
         )
@@ -126,26 +123,6 @@ fun ClockPage(
             )
         }
     }
-}
-
-@Composable
-@Preview
-fun batteryWarningDialog(
-    confirmFunction: () -> Unit = {},
-    dismissFunction: () -> Unit = {}
-) {
-    AlertDialog(
-        modifier = Modifier,
-        onDismissRequest = dismissFunction,
-        title = { Text("Hey guess what?") },
-        text = { Text("So there's some stuff that you gotta do with the battery settings and stuff? Yeah, that's pretty annoying.\n\nDo you mind changing those things? Thanks.")},
-        confirmButton = { TextButton(onClick = confirmFunction) {
-            Text(text = "Confirm".uppercase())
-        }},
-        dismissButton = { TextButton(onClick = dismissFunction) {
-            Text("Deny".uppercase())
-        }}
-    )
 }
 
 @Composable

--- a/app/src/main/java/com/nickspatties/timeclock/ui/viewmodel/ClockPageViewModel.kt
+++ b/app/src/main/java/com/nickspatties/timeclock/ui/viewmodel/ClockPageViewModel.kt
@@ -92,7 +92,7 @@ class ClockPageViewModel (
         setOnChronometerTickListener { countDown() }
     }
 
-    // alarm manager
+    // Android system managers
     private val alarmManager =
         getApplication<Application>().getSystemService(Context.ALARM_SERVICE) as AlarmManager
     private val powerManager =

--- a/app/src/main/java/com/nickspatties/timeclock/ui/viewmodel/ClockPageViewModel.kt
+++ b/app/src/main/java/com/nickspatties/timeclock/ui/viewmodel/ClockPageViewModel.kt
@@ -26,11 +26,10 @@ import androidx.lifecycle.Transformations
 import androidx.lifecycle.viewModelScope
 import com.nickspatties.timeclock.MainActivity
 import com.nickspatties.timeclock.R
-import com.nickspatties.timeclock.data.TimeClockEvent
-import com.nickspatties.timeclock.data.TimeClockEventDao
-import com.nickspatties.timeclock.data.UserPreferencesRepository
+import com.nickspatties.timeclock.data.*
 import com.nickspatties.timeclock.receiver.AlarmReceiver
 import com.nickspatties.timeclock.util.*
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 
@@ -38,10 +37,11 @@ import kotlinx.coroutines.launch
 const val TAG = "ClockPageViewModel"
 
 class ClockPageViewModel (
-    private val database: TimeClockEventDao,
     application: Application,
+    private val database: TimeClockEventDao,
+    private val timeClockEvents: LiveData<List<TimeClockEvent>>,
     private val userPreferencesRepository: UserPreferencesRepository,
-    private val timeClockEvents: LiveData<List<TimeClockEvent>>
+    private val userPreferencesImportFlow: Flow<UserPreferences> = userPreferencesRepository.userPreferencesFlow
 ): AndroidViewModel(application) {
 
     val autofillTaskNames = Transformations.map(timeClockEvents) { events ->
@@ -220,7 +220,10 @@ class ClockPageViewModel (
             countDownTimerEnabled = !countDownTimerEnabled
             clockButtonEnabled = checkClockButtonEnabled()
             viewModelScope.launch {
-                userPreferencesRepository.updateCountDownEnabled(countDownTimerEnabled)
+                userPreferencesRepository.updatePreference(
+                    PreferenceKeys.COUNT_DOWN_ENABLED,
+                    countDownTimerEnabled
+                )
             }
         }
     }
@@ -445,6 +448,15 @@ class ClockPageViewModel (
             updateFields = this::updateCountDownTextFieldValues
         )
     }
+
+    /**
+     * Constuctor to create mock versions of the ClockPageViewModel
+     *
+     * This allows me to preview the ClockPage component with variables of my choosing
+     */
+//    constructor(longNum: Long) : this() {
+//
+//    }
 }
 
 /**

--- a/app/src/main/java/com/nickspatties/timeclock/ui/viewmodel/ClockPageViewModel.kt
+++ b/app/src/main/java/com/nickspatties/timeclock/ui/viewmodel/ClockPageViewModel.kt
@@ -68,7 +68,9 @@ class ClockPageViewModel (
     private var notificationManager = getNotificationManager(getApplication())
 
     // countdown specific variables
+    var batteryWarningDialogVisible by mutableStateOf(false)
     var countDownTimerEnabled by mutableStateOf(false)
+    var countDownWarningEnabled by mutableStateOf(true)
     var countDownEndTime by mutableStateOf(0L)
     var currCountDownSeconds by mutableStateOf(0)
     private val defaultTextFieldValue = TextFieldValue(
@@ -93,6 +95,7 @@ class ClockPageViewModel (
         viewModelScope.launch {
             val preferences = userPreferencesFlow.first()
             countDownTimerEnabled = preferences.countDownEnabled
+            countDownWarningEnabled = preferences.countDownWarningEnabled
             countDownEndTime = preferences.countDownEndTime
 
             // initialize the currentEvent in case the app was closed while counting
@@ -192,11 +195,23 @@ class ClockPageViewModel (
     }
 
     fun switchCountDownTimer() {
-        countDownTimerEnabled = !countDownTimerEnabled
-        clockButtonEnabled = checkClockButtonEnabled()
-        viewModelScope.launch {
-            userPreferencesRepository.updateCountDownEnabled(countDownTimerEnabled)
-        }
+//        if (countDownWarningEnabled) {
+//            batteryWarningDialogVisible = true
+//        } else {
+            countDownTimerEnabled = !countDownTimerEnabled
+            clockButtonEnabled = checkClockButtonEnabled()
+            viewModelScope.launch {
+                userPreferencesRepository.updateCountDownEnabled(countDownTimerEnabled)
+            }
+//        }
+    }
+
+    fun hideBatteryWarningModal() {
+        batteryWarningDialogVisible = false
+    }
+
+    fun goToBatterySettings() {
+        // TODO take user to battery settings
     }
 
     fun onMinuteValueChange(value: TextFieldValue) {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -10,8 +10,8 @@
     <string name="task_text_field_label">What are you gonna do now?</string>
     <string name="task_text_field_placeholder">Right now, I\'m gonna be…</string>
     <string name="battery_warning_dialog_title">Update battery usage settings</string>
-    <string name="battery_warning_dialog_body">The count down alarm may not work properly with the current settings.\n\nPlease set this app\'s battery usage settings to \"Unrestricted\" to ensure the alarm works as intended.</string>
-    <string name="battery_warning_dialog_action">Go to App Settings</string>
+    <string name="battery_warning_dialog_body">The count down alarm may not work properly with your device\'s current battery settings.\n\nPlease allow TimeClock to run in the background to ensure the count down alarm works as intended.</string>
+    <string name="battery_warning_dialog_action">Request Permission</string>
     <string name="list_page_nothing_here">Looks like there\'s nothing here… Record some events to fill this list!</string>
     <string name="list_page_in_progress">In progress…</string>
     <string name="start_time">Start time</string>
@@ -30,5 +30,9 @@
     <string name="clock_channel_name">Clock Page Controls</string>
     <string name="alarm_channel_id" translatable="false">alarm_channel</string>
     <string name="alarm_channel_name">Countdown Alarm</string>
+
+    <string name="battery_warning_dialog_title_2">Update battery usage settings</string>
+    <string name="battery_warning_dialog_body_2">The count down alarm may not work properly with the current settings.\n\nPlease set this app\'s battery usage settings to \"Unrestricted\" to ensure the alarm works as intended.</string>
+    <string name="battery_warning_dialog_action_2">Go to App Settings</string>
 
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -9,6 +9,9 @@
     <string name="task_saved_toast">Task \"%s\" saved!</string>
     <string name="task_text_field_label">What are you gonna do now?</string>
     <string name="task_text_field_placeholder">Right now, I\'m gonna be…</string>
+    <string name="battery_warning_dialog_title">Update battery usage settings</string>
+    <string name="battery_warning_dialog_body">The count down alarm may not work properly with the current settings.\n\nPlease set this app\'s battery usage settings to \"Unrestricted\" to ensure the alarm works as intended.</string>
+    <string name="battery_warning_dialog_action">Go to App Settings</string>
     <string name="list_page_nothing_here">Looks like there\'s nothing here… Record some events to fill this list!</string>
     <string name="list_page_in_progress">In progress…</string>
     <string name="start_time">Start time</string>


### PR DESCRIPTION
### Changes
Allow users to adjust their battery settings from within the app. When a user selects the count down icon, if their battery permissions are not "Unrestricted", then they are prompted with a dialog to grant the app access to those permissions.

Note that this change really effects android devices including and past API 23 (Marshmallow), since battery permissions can actually be adjusted. API versions are not effected by this change.

### Related issues
#19 #12 

### Testing
* Manual testing