### PR TITLE
Move battery warning functionality to ClockPageViewModelState

### DIFF
--- a/app/src/androidTest/java/com/nickspatties/timeclock/ui/pages/ClockPageTest.kt
+++ b/app/src/androidTest/java/com/nickspatties/timeclock/ui/pages/ClockPageTest.kt
@@ -47,6 +47,44 @@ class ClockPageTest {
     }
 
     @Test
+    fun taskNameIcon_countDownTimerAppears() {
+        composeTestRule.setContent {
+            TimeClockTheme {
+                ClockPage(
+                    viewModelState = ClockPageViewModelState()
+                )
+            }
+        }
+        composeTestRule.onNodeWithTag("TaskTextField_IconButton").performClick()
+        composeTestRule.onNodeWithTag("TimerTextField_Hours")
+            .assertIsDisplayed()
+            .assertIsEnabled()
+        composeTestRule.onNodeWithTag("TimerTextField_Minutes")
+            .assertIsDisplayed()
+            .assertIsEnabled()
+        composeTestRule.onNodeWithTag("TimerTextField_Seconds")
+            .assertIsDisplayed()
+            .assertIsEnabled()
+    }
+
+    @Test
+    fun taskNameIcon_countDownTimerDisappearsIfAlreadyEnabled() {
+        composeTestRule.setContent {
+            TimeClockTheme {
+                ClockPage(
+                    viewModelState = ClockPageViewModelState(
+                        countDownTimerEnabled = true
+                    )
+                )
+            }
+        }
+        composeTestRule.onNodeWithTag("TaskTextField_IconButton").performClick()
+        composeTestRule.onNodeWithTag("TimerTextField_Hours").assertDoesNotExist()
+        composeTestRule.onNodeWithTag("TimerTextField_Minutes").assertDoesNotExist()
+        composeTestRule.onNodeWithTag("TimerTextField_Seconds").assertDoesNotExist()
+    }
+
+    @Test
     fun taskNameDropdown_dropdownAppearsAndTaskFillsInWhenLabelIsClicked() {
         composeTestRule.setContent {
             TimeClockTheme {

--- a/app/src/main/java/com/nickspatties/timeclock/ui/pages/ClockPage.kt
+++ b/app/src/main/java/com/nickspatties/timeclock/ui/pages/ClockPage.kt
@@ -30,7 +30,7 @@ fun ClockPage(
     if (viewModelState.batteryWarningDialogVisible) {
         BatteryWarningDialog(
             confirmFunction = viewModelState.batteryWarningConfirmFunction,
-            dismissFunction = viewModelState.batteryWarningDismissFunction
+            dismissFunction = viewModelState::dismissBatteryWarningDialog
         )
     }
 
@@ -137,5 +137,15 @@ fun ClockPage(
 fun ClockPage_Initial() {
     ClockPage(
         viewModelState = ClockPageViewModelState()
+    )
+}
+
+@Composable
+@Preview
+fun ClockPage_batteryDialogVisible() {
+    ClockPage(
+        viewModelState = ClockPageViewModelState(
+            batteryWarningDialogVisible = true
+        )
     )
 }

--- a/app/src/main/java/com/nickspatties/timeclock/ui/pages/ClockPage.kt
+++ b/app/src/main/java/com/nickspatties/timeclock/ui/pages/ClockPage.kt
@@ -29,7 +29,7 @@ fun ClockPage(
 
     if (viewModelState.batteryWarningDialogVisible) {
         BatteryWarningDialog(
-            confirmFunction = viewModelState.batteryWarningConfirmFunction,
+            confirmFunction = viewModelState::confirmBatteryWarningDialog,
             dismissFunction = viewModelState::dismissBatteryWarningDialog
         )
     }

--- a/app/src/main/java/com/nickspatties/timeclock/ui/pages/ClockPage.kt
+++ b/app/src/main/java/com/nickspatties/timeclock/ui/pages/ClockPage.kt
@@ -34,7 +34,7 @@ fun ClockPage(
         )
     }
 
-    Scaffold() {
+    Scaffold {
         Column(
             modifier = Modifier
                 .padding(it)
@@ -63,7 +63,7 @@ fun ClockPage(
                     },
                     keyboardController = keyboardController,
                     countdownTimerEnabled = viewModelState.countDownTimerEnabled,
-                    onIconClick = viewModelState.onTaskNameIconClick
+                    onIconClick = viewModelState::onTaskTextFieldIconClick
                 )
 
                 DropdownMenu(

--- a/app/src/main/java/com/nickspatties/timeclock/ui/viewmodel/ClockPageViewModel.kt
+++ b/app/src/main/java/com/nickspatties/timeclock/ui/viewmodel/ClockPageViewModel.kt
@@ -83,7 +83,7 @@ class ClockPageViewModel (
     // only occurs when the class is created, not when moving from view to view
     init {
         // state function declarations
-        state.batteryWarningConfirmFunction = this::goToBatterySettings
+        state.startBatteryManagementActivity = this::goToBatterySettings
         state.onTaskNameIconClick = this::switchCountDownTimer
         state.onTimerAnimationFinish = this::resetCurrSeconds
         state.onClockStart = this::startClock
@@ -174,7 +174,6 @@ class ClockPageViewModel (
                 Uri.parse("package:" + getApplication<Application?>().packageName)
             startActivity(getApplication(), intentBatteryUsage, null)
         }
-        state.dismissBatteryWarningDialog()
     }
 
     private fun timerTextFieldValuesToSeconds(): Int {
@@ -326,8 +325,7 @@ fun getCountDownSeconds(
  * not exceed 59
  * @param secondsTextFieldValue The text in the minutes section of the EditTimerTextField. Should
  * not exceed 59
- * @param batteryWarningConfirmFunction Fires when tapping confirm button in BatteryWarningDialog
- * @param dismissBatteryWarningDialog Fires when tapping outside the BatteryWarningDialog
+ * @param startBatteryManagementActivity Starts battery management activity
  * @param onTaskNameIconClick Fires when the icon in the TaskTextField is pushed. Changes from
  * count up to count down mode.
  * @param onDismissDropdown Fires when the dropdown in the TaskTextField is dismissed by tapping outside it
@@ -355,7 +353,7 @@ class ClockPageViewModelState(
         text = "00",
         selection = TextRange(0)
     ),
-    var batteryWarningConfirmFunction: () -> Unit = {},
+    var startBatteryManagementActivity: () -> Unit = {},
     var onTaskNameIconClick: () -> Unit = {},
     var onDismissDropdown: () -> Unit = {},
     var onTimerAnimationFinish: () -> Unit = {},
@@ -395,6 +393,11 @@ class ClockPageViewModelState(
     var dropdownClicked = false
 
     fun dismissBatteryWarningDialog() {
+        batteryWarningDialogVisible = false
+    }
+
+    fun confirmBatteryWarningDialog() {
+        startBatteryManagementActivity()
         batteryWarningDialogVisible = false
     }
 

--- a/app/src/main/java/com/nickspatties/timeclock/ui/viewmodel/ClockPageViewModel.kt
+++ b/app/src/main/java/com/nickspatties/timeclock/ui/viewmodel/ClockPageViewModel.kt
@@ -322,6 +322,8 @@ fun getCountDownSeconds(
  * @param checkBatteryOptimizationSettings Verifies whether or not the TimeClock has unrestricted
  * battery permission. If it doesn't, then the battery warning dialog should appear.
  * @param startBatteryManagementActivity Starts battery management activity
+ * @param saveCountDownTimerEnabledValue Saves the countDownTimerEnabled UserPreference variable, so
+ * the count down timer's visibility persists on activity recreation
  * @param onDismissDropdown Fires when the dropdown in the TaskTextField is dismissed by
  * tapping outside it
  * @param onTimerAnimationFinish Fires when the count up timer fades in and out when starting

--- a/app/src/main/java/com/nickspatties/timeclock/ui/viewmodel/ClockPageViewModel.kt
+++ b/app/src/main/java/com/nickspatties/timeclock/ui/viewmodel/ClockPageViewModel.kt
@@ -84,7 +84,6 @@ class ClockPageViewModel (
     init {
         // state function declarations
         state.batteryWarningConfirmFunction = this::goToBatterySettings
-        state.batteryWarningDismissFunction = this::hideBatteryWarningModal
         state.onTaskNameIconClick = this::switchCountDownTimer
         state.onTimerAnimationFinish = this::resetCurrSeconds
         state.onClockStart = this::startClock
@@ -158,9 +157,7 @@ class ClockPageViewModel (
         }
     }
 
-    fun hideBatteryWarningModal() {
-        state.batteryWarningDialogVisible = false
-    }
+
 
     /**
      * Allow user to give TimeClock permission to run in the background unrestricted, which
@@ -177,7 +174,7 @@ class ClockPageViewModel (
                 Uri.parse("package:" + getApplication<Application?>().packageName)
             startActivity(getApplication(), intentBatteryUsage, null)
         }
-        hideBatteryWarningModal()
+        state.dismissBatteryWarningDialog()
     }
 
     private fun timerTextFieldValuesToSeconds(): Int {
@@ -330,7 +327,7 @@ fun getCountDownSeconds(
  * @param secondsTextFieldValue The text in the minutes section of the EditTimerTextField. Should
  * not exceed 59
  * @param batteryWarningConfirmFunction Fires when tapping confirm button in BatteryWarningDialog
- * @param batteryWarningDismissFunction Fires when tapping outside the BatteryWarningDialog
+ * @param dismissBatteryWarningDialog Fires when tapping outside the BatteryWarningDialog
  * @param onTaskNameIconClick Fires when the icon in the TaskTextField is pushed. Changes from
  * count up to count down mode.
  * @param onDismissDropdown Fires when the dropdown in the TaskTextField is dismissed by tapping outside it
@@ -359,7 +356,6 @@ class ClockPageViewModelState(
         selection = TextRange(0)
     ),
     var batteryWarningConfirmFunction: () -> Unit = {},
-    var batteryWarningDismissFunction: () -> Unit = {},
     var onTaskNameIconClick: () -> Unit = {},
     var onDismissDropdown: () -> Unit = {},
     var onTimerAnimationFinish: () -> Unit = {},
@@ -397,6 +393,10 @@ class ClockPageViewModelState(
     var secondsTextFieldValue by mutableStateOf(secondsTextFieldValue)
     // cheeky var used to prevent onTaskNameChange from being called after onDropdownMenuItemClick
     var dropdownClicked = false
+
+    fun dismissBatteryWarningDialog() {
+        batteryWarningDialogVisible = false
+    }
 
     fun onTaskNameChange(tfv: TextFieldValue) {
         if (dropdownClicked) {

--- a/app/src/test/java/com/nickspatties/timeclock/ui/viewmodel/ClockPageViewModelTest.kt
+++ b/app/src/test/java/com/nickspatties/timeclock/ui/viewmodel/ClockPageViewModelTest.kt
@@ -266,4 +266,27 @@ class ClockPageViewModelStateTest {
         testState.dismissBatteryWarningDialog()
         assertThat(testState.batteryWarningDialogVisible).isFalse()
     }
+
+    @Test
+    fun onTaskTextFieldIconClick_switchesCountDownTimerEnabled() {
+        var counter = 0
+        val testState = ClockPageViewModelState(
+            countDownTimerEnabled = false,
+            saveCountDownTimerEnabledValue = { counter++ }
+        )
+        testState.onTaskTextFieldIconClick()
+        assertThat(testState.countDownTimerEnabled).isTrue()
+        assertThat(counter).isEqualTo(1) // saveCountDownTimerEnabled has been called
+    }
+
+    @Test
+    fun onTaskTextFieldIconClick_shouldWarnIfBatterySettingsNotOptimized() {
+        val testState = ClockPageViewModelState(
+            checkBatteryOptimizationSettings = { true },
+            countDownTimerEnabled = false
+        )
+        testState.onTaskTextFieldIconClick()
+        assertThat(testState.countDownTimerEnabled).isFalse()
+        assertThat(testState.batteryWarningDialogVisible).isTrue()
+    }
 }

--- a/app/src/test/java/com/nickspatties/timeclock/ui/viewmodel/ClockPageViewModelTest.kt
+++ b/app/src/test/java/com/nickspatties/timeclock/ui/viewmodel/ClockPageViewModelTest.kt
@@ -245,6 +245,20 @@ class ClockPageViewModelStateTest {
     }
 
     @Test
+    fun confirmBatteryWarningDialog_callsStartBatteryManagementActivityFunction() {
+        var counter = 0
+        val testState = ClockPageViewModelState(
+            batteryWarningDialogVisible = true,
+            startBatteryManagementActivity = {
+                counter++
+            }
+        )
+        testState.confirmBatteryWarningDialog()
+        assertThat(counter).isEqualTo(1)
+        assertThat(testState.batteryWarningDialogVisible).isFalse()
+    }
+
+    @Test
     fun dismissBatteryWarningDialog_dialogNotVisibleAfterDismiss() {
         val testState = ClockPageViewModelState(
             batteryWarningDialogVisible = true

--- a/app/src/test/java/com/nickspatties/timeclock/ui/viewmodel/ClockPageViewModelTest.kt
+++ b/app/src/test/java/com/nickspatties/timeclock/ui/viewmodel/ClockPageViewModelTest.kt
@@ -243,4 +243,13 @@ class ClockPageViewModelStateTest {
             )
         )
     }
+
+    @Test
+    fun dismissBatteryWarningDialog_dialogNotVisibleAfterDismiss() {
+        val testState = ClockPageViewModelState(
+            batteryWarningDialogVisible = true
+        )
+        testState.dismissBatteryWarningDialog()
+        assertThat(testState.batteryWarningDialogVisible).isFalse()
+    }
 }


### PR DESCRIPTION
### Changes
Continuing moving state logic from `ClockPageViewModel` to `ClockPageViewModelState`
* TaskTextField icon click function
* Swapping visibility of `EditTimerTextField` when clicking the icon
* Saving `UserPreferences` data in the ViewModel when clicking the icon using functions passed into ViewModelState

### Related issue
Continuation of #24 

### Testing
* Manual testing
* Unit tests
* Integration tests using my device